### PR TITLE
Fix setup.py, remove an unextisting script reference

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
     install_requires=[
         'selenium'
     ],
-    scripts=['bin/nose_runner.py'],
     author='GEM Foundation',
     author_email='devops@openquake.org',
     maintainer='GEM Foundation',


### PR DESCRIPTION
`pip install -e` was broken:

```python
Obtaining file:///home/daniele/GIT/gem/oq-platform/oq-moon
Requirement already satisfied: selenium in /home/daniele/GIT/gem/oq-platform/standalone10/lib/python2.7/site-packages (from openquake.moon==0.3.0)
Installing collected packages: openquake.moon
  Running setup.py develop for openquake.moon
    Complete output from command /home/daniele/GIT/gem/oq-platform/standalone10/bin/python2 -c "import setuptools, tokenize;__file__='/home/daniele/GIT/gem/oq-platform/oq-moon/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" develop --no-deps:
    running develop
    running egg_info
    writing requirements to openquake.moon.egg-info/requires.txt
    writing openquake.moon.egg-info/PKG-INFO
    writing namespace_packages to openquake.moon.egg-info/namespace_packages.txt
    writing top-level names to openquake.moon.egg-info/top_level.txt
    writing dependency_links to openquake.moon.egg-info/dependency_links.txt
    warning: manifest_maker: standard file '-c' not found
    
    reading manifest file 'openquake.moon.egg-info/SOURCES.txt'
    writing manifest file 'openquake.moon.egg-info/SOURCES.txt'
    running build_ext
    Creating /home/daniele/GIT/gem/oq-platform/standalone10/lib/python2.7/site-packages/openquake.moon.egg-link (link to .)
    Adding openquake.moon 0.3.0 to easy-install.pth file
    error: [Errno 2] No such file or directory: '/home/daniele/GIT/gem/oq-platform/oq-moon/bin/nose_runner.py'
    
    ----------------------------------------
```