### PR TITLE
add existence check for test optional folders

### DIFF
--- a/openquake/moon/__init__.py
+++ b/openquake/moon/__init__.py
@@ -20,6 +20,6 @@ from .utils import TimeoutError, NotUniqError
 from .failurecatcher import FailureCatcher
 from .platform import platform_get, platform_del
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __all__ = ['FailureCatcher', 'Moon', 'TimeoutError', 'NotUniqError',
            'platform_get', 'platform_del']

--- a/openquake/moon/nose_runner.py
+++ b/openquake/moon/nose_runner.py
@@ -29,10 +29,14 @@ if __name__ == '__main__':
         for pkg_name in pkgs:
             try:
                 pkg = __import__(pkg_name)
-                paths.append(os.path.join(os.path.dirname(pkg.__file__),
-                             'test'))
+                new_path = os.path.join(os.path.dirname(pkg.__file__),
+                                        'test')
+                if os.path.isdir(new_path) is False:
+                    continue
+                print("ADDING NEW TESTS PATH: [%s]" % new_path)
+                paths.append(new_path)
             except ImportError:
                 pass
-        print(paths)
+        print("TESTS PATHS: %s" % paths)
 
     nose.main(addplugins=[FailureCatcher()], argv=(sys.argv + paths))

--- a/openquake/moon/nose_runner.py
+++ b/openquake/moon/nose_runner.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
                 pkg = __import__(pkg_name)
                 new_path = os.path.join(os.path.dirname(pkg.__file__),
                                         'test')
-                if os.path.isdir(new_path) is False:
+                if not os.path.isdir(new_path):
                     continue
                 print("ADDING NEW TESTS PATH: [%s]" % new_path)
                 paths.append(new_path)


### PR DESCRIPTION
With this PR we align `oq-platform` with the new test schema developed on `oq-platform-standalone`.
Tests on `oq-platform` are green: https://ci.openquake.org/job/zdevel_oq-platform/470/
Tests on `oq-platform-standalone` are green: https://ci.openquake.org/job/zdevel_oq-platform-standalone/182/