### PR TITLE
Get repos from dict pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+import warnings
+
+def pytest_configure(config):
+    warnings.filterwarnings("ignore", category=ImportWarning, module="nose")
+

--- a/openquake/moon/__init__.py
+++ b/openquake/moon/__init__.py
@@ -17,10 +17,10 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 from .base import Moon
 from .utils import TimeoutError, NotUniqError
-from .failurecatcher import FailureCatcher
+# from .failurecatcher import FailureCatcher
 from .platform import platform_get, platform_del
 
 __version__ = "1.2.0"
 
-__all__ = ['FailureCatcher', 'Moon', 'TimeoutError', 'NotUniqError',
+__all__ = ['Moon', 'TimeoutError', 'NotUniqError',
            'platform_get', 'platform_del']

--- a/openquake/moon/test/__init__.py
+++ b/openquake/moon/test/__init__.py
@@ -46,8 +46,9 @@ def setup_package():
 #    pla.fini()
 
 def my_at_exit():
-    _httpserver.shutdown()
-    _httpserver_thread.join(5)
+    if _httpserver:
+        _httpserver.shutdown()
+        _httpserver_thread.join(5)
     pla.fini()
 
 atexit.register(my_at_exit)

--- a/openquake/moon/test/__init__.py
+++ b/openquake/moon/test/__init__.py
@@ -3,8 +3,8 @@ import atexit
 
 import sys, os, time
 import threading
-from SimpleHTTPServer import SimpleHTTPRequestHandler
-from BaseHTTPServer import HTTPServer
+from http.server import SimpleHTTPRequestHandler 
+from http.server import HTTPServer
 
 PUBLIC_DIRECTORY = os.path.join(os.path.dirname(__file__), 'webpages')
 

--- a/openquake/moon/test/__init__.py
+++ b/openquake/moon/test/__init__.py
@@ -1,10 +1,11 @@
 from openquake.moon import Moon
-import atexit
+import os
+# import atexit
 
-import sys, os, time
-import threading
+# import sys, os, time
+# import threading
 from http.server import SimpleHTTPRequestHandler 
-from http.server import HTTPServer
+# from http.server import HTTPServer
 
 PUBLIC_DIRECTORY = os.path.join(os.path.dirname(__file__), 'webpages')
 
@@ -22,34 +23,34 @@ _httpserver_thread = None
 pla = Moon()
 pla.primary_set()
 
-def setup_package():
-    global _httpserver, _httpserver_thread
-    _httpserver = HTTPServer(('', 8008), MyRequestHandler)
-    _httpserver_thread = threading.Thread(target = _httpserver.serve_forever)
-    _httpserver_thread.daemon = True
-    try:
-        _httpserver_thread.start()
-    except KeyboardInterrupt:
-        _httpserver_thread.shutdown()
-        sys.exit(0)
-    for i in range(1,1000):
-        if _httpserver_thread.is_alive():
-            break
-        time.sleep(0.2)
-        continue
+# def setup_package():
+#     global _httpserver, _httpserver_thread
+#     _httpserver = HTTPServer(('', 8008), MyRequestHandler)
+#     _httpserver_thread = threading.Thread(target = _httpserver.serve_forever)
+#     _httpserver_thread.daemon = True
+#     try:
+#         _httpserver_thread.start()
+#     except KeyboardInterrupt:
+#         _httpserver_thread.shutdown()
+#         sys.exit(0)
+#     for i in range(1,1000):
+#         if _httpserver_thread.is_alive():
+#             break
+#         time.sleep(0.2)
+#         continue
             
-    pla.init(landing="/index.html", autologin=False)
+#     pla.init(landing="/index.html", autologin=False)
 
 # turned off because nose run it at the wrong time
 #def teardown_package():
 #    print("teardown_package here")
 #    pla.fini()
 
-def my_at_exit():
-    if _httpserver:
-        _httpserver.shutdown()
-        _httpserver_thread.join(5)
-    pla.fini()
+# def my_at_exit():
+#     if _httpserver:
+#         _httpserver.shutdown()
+#         _httpserver_thread.join(5)
+#     # pla.fini()
 
-atexit.register(my_at_exit)
+# atexit.register(my_at_exit)
 

--- a/openquake/moon/test/conftest.py
+++ b/openquake/moon/test/conftest.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import time
+import pytest
+from http.server import SimpleHTTPRequestHandler 
+from http.server import HTTPServer
+import threading
+
+from openquake.moon.test import pla
+
+PUBLIC_DIRECTORY = os.path.join(os.path.dirname(__file__), 'webpages')
+
+class MyRequestHandler(SimpleHTTPRequestHandler):
+    def translate_path(self, path):
+        print("PATH: [%s]" % path)
+        if path == '/':
+            return PUBLIC_DIRECTORY + os.sep + 'index.html'
+        else:
+            return PUBLIC_DIRECTORY + os.sep.join(path.split('/'))
+
+
+@pytest.fixture(scope="package", autouse=True)
+def package_setup_teardown():
+    # --- SETUP CODE GOES HERE ---
+    print("\n[Setup] This runs ONCE before any tests in this package start")
+    global _httpserver, _httpserver_thread
+    _httpserver = HTTPServer(('', 8008), MyRequestHandler)
+    _httpserver_thread = threading.Thread(target = _httpserver.serve_forever)
+    _httpserver_thread.daemon = True
+    try:
+        _httpserver_thread.start()
+    except KeyboardInterrupt:
+        _httpserver_thread.shutdown()
+        sys.exit(0)
+    for i in range(1,1000):
+        if _httpserver_thread.is_alive():
+            break
+        time.sleep(0.2)
+        continue
+            
+    pla.init(landing="/index.html", autologin=False)
+    
+    yield  # This tells pytest to go execute all the tests
+    
+    # --- TEARDOWN CODE GOES HERE ---
+    print("\n[Teardown] This runs ONCE after all tests in this package finish")
+
+    pla.fini()
+    

--- a/openquake/moon/test/screenshot_test.py
+++ b/openquake/moon/test/screenshot_test.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 import unittest
-from nose.plugins.attrib import attr
+import pytest
+# from nose.plugins.attrib import attr
 from openquake.moon.test import pla
 
+@pytest.mark.skip(reason="disable screenshots during first phase of nose-pytest migration")
 class ScreenshotTest(unittest.TestCase):
-    @attr('negate')
+#    @attr('negate')
     def screenshot_test(self):
         pla.get('/screenshot_test.html')
 

--- a/openquake/moon/test/test_dumb.py
+++ b/openquake/moon/test/test_dumb.py
@@ -2,5 +2,5 @@ import unittest
 
 
 class DumbTest(unittest.TestCase):
-    def dumb_test(self):
+    def test_dumb(self):
         pass

--- a/openquake/moon/test/test_scroll.py
+++ b/openquake/moon/test/test_scroll.py
@@ -5,7 +5,7 @@ from openquake.moon.test import pla
 from selenium.webdriver.common.keys import Keys
 
 class ScrollTest(unittest.TestCase):
-    def scroll_to_a_test(self):
+    def test_scroll_to_a(self):
         pla.get('/scroll_test.html')
 
         hyperlink_res = pla.xpath_finduniq("//div[@id='hyperlink-click']",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = '1.2.0'
 
 dependencies = [
   'selenium ~= 4.46.0',
-  'nose3 ~= 1.3.8'
+  'pytest ~= 9.1.1',
 ]
 
 requires-python = '>=3'

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -29,7 +29,7 @@ exec_test () {
     wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
     tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
     sudo cp geckodriver /usr/local/bin
-    sudo pip install -U selenium==${GEM_SELENIUM_VERSION}
+    pip install -U selenium==${GEM_SELENIUM_VERSION}
 
     cp $GEM_GIT_PACKAGE/openquake/moon/test/config/moon_config.py.tmpl $GEM_GIT_PACKAGE/openquake/moon/test/config/moon_config.py
     export DISPLAY=:1

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -39,10 +39,13 @@ exec_test () {
     err=0
     # python -m openquake.moon.nose_runner --failurecatcher dev -s -v -a '!negate' --with-xunit --xunit-file=xunit-moon-dev.xml $GEM_GIT_PACKAGE/openquake/moon/test || err=1
     pytest --tb=short -vs $GEM_GIT_PACKAGE/openquake/moon/test || err=1
-    for negate_file in screenshot_test; do
+    # for negate_file in screenshot_test; do
+    # FIXME temporarily disable as first step of nose to pytest migration
+    for negate_file in; do
         beg_date="$(date "+%d/%b/%Y %H:%M:%S")"
         time_begin="$(date +%s%N)"
-        python -m openquake.moon.nose_runner --failurecatcher dev-neg -s -v -a 'negate' --with-xunit --xunit-file=xunit-moon-dev-neg.xml "$GEM_GIT_PACKAGE/openquake/moon/test/${negate_file}.py" || true
+        # python -m openquake.moon.nose_runner --failurecatcher dev-neg -s -v -a 'negate' --with-xunit --xunit-file=xunit-moon-dev-neg.xml "$GEM_GIT_PACKAGE/openquake/moon/test/${negate_file}.py" || true
+        pytest --tb=short -vs $GEM_GIT_PACKAGE/openquake/moon/test || err=1
         time_end="$(date +%s%N)"
         float_sec_time="$(echo "($time_end - $time_begin) / 1000000000" | bc -l | sed 's/\.\([0-9]\{3\}\).*$/.\1/g')"
         if [ ! -f  dev-neg_openquake.moon.test.*.${negate_file}.png ]; then

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -31,6 +31,7 @@ exec_test () {
     sudo cp geckodriver /usr/local/bin
     # selenium arrives from oq-moon deps
     # pip install -U selenium==${GEM_SELENIUM_VERSION}
+    pip install $HOME/$GEM_GIT_PACKAGE
 
     cp $GEM_GIT_PACKAGE/openquake/moon/test/config/moon_config.py.tmpl $GEM_GIT_PACKAGE/openquake/moon/test/config/moon_config.py
     export DISPLAY=:1

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -38,7 +38,7 @@ exec_test () {
     export PYTHONPATH=$HOME/$GEM_GIT_PACKAGE:$HOME/$GEM_GIT_PACKAGE/openquake/moon/test/config
     err=0
     # python -m openquake.moon.nose_runner --failurecatcher dev -s -v -a '!negate' --with-xunit --xunit-file=xunit-moon-dev.xml $GEM_GIT_PACKAGE/openquake/moon/test || err=1
-    pytest -vs $GEM_GIT_PACKAGE/openquake/moon/test || err=1
+    pytest --tb=short -vs $GEM_GIT_PACKAGE/openquake/moon/test || err=1
     for negate_file in screenshot_test; do
         beg_date="$(date "+%d/%b/%Y %H:%M:%S")"
         time_begin="$(date +%s%N)"

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -15,13 +15,11 @@ sudo apt-get -y upgrade
 
 #function complete procedure for tests
 exec_test () {    
-    #install selenium,pip,geckodriver,clone oq-moon and execute tests with nose 
     sudo apt-get -y install python3-pip bc python3-venv
     python3 -m venv venv
     . ./venv/bin/activate
     echo VIRTUAL_ENV: $VIRTUAL_ENV
     pip install --upgrade pip
-    pip install nose
 
     wget "http://ftp.openquake.org/common/selenium-deps-2026"
     GEM_FIREFOX_VERSION="$(dpkg-query --show -f '${Version}' firefox)"

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -25,7 +25,7 @@ exec_test () {
 
     wget "http://ftp.openquake.org/common/selenium-deps-2026"
     GEM_FIREFOX_VERSION="$(dpkg-query --show -f '${Version}' firefox)"
-    . selenium-deps
+    . selenium-deps-2026
     wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
     tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
     sudo cp geckodriver /usr/local/bin

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -37,7 +37,8 @@ exec_test () {
     export DISPLAY=:1
     export PYTHONPATH=$HOME/$GEM_GIT_PACKAGE:$HOME/$GEM_GIT_PACKAGE/openquake/moon/test/config
     err=0
-    python -m openquake.moon.nose_runner --failurecatcher dev -s -v -a '!negate' --with-xunit --xunit-file=xunit-moon-dev.xml $GEM_GIT_PACKAGE/openquake/moon/test || err=1
+    # python -m openquake.moon.nose_runner --failurecatcher dev -s -v -a '!negate' --with-xunit --xunit-file=xunit-moon-dev.xml $GEM_GIT_PACKAGE/openquake/moon/test || err=1
+    pytest -vs $GEM_GIT_PACKAGE/openquake/moon/test || err=1
     for negate_file in screenshot_test; do
         beg_date="$(date "+%d/%b/%Y %H:%M:%S")"
         time_begin="$(date +%s%N)"

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -16,7 +16,7 @@ sudo apt-get -y upgrade
 #function complete procedure for tests
 exec_test () {    
     #install selenium,pip,geckodriver,clone oq-moon and execute tests with nose 
-    sudo apt-get -y install python-pip bc python3-venv
+    sudo apt-get -y install python3-pip bc python3-venv
     python3 -m venv venv
     . ./venv/bin/activate
     echo VIRTUAL_ENV: $VIRTUAL_ENV

--- a/verifier-guest.sh
+++ b/verifier-guest.sh
@@ -29,7 +29,8 @@ exec_test () {
     wget "http://ftp.openquake.org/mirror/mozilla/geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
     tar zxvf "geckodriver-v${GEM_GECKODRIVER_VERSION}-linux64.tar.gz"
     sudo cp geckodriver /usr/local/bin
-    pip install -U selenium==${GEM_SELENIUM_VERSION}
+    # selenium arrives from oq-moon deps
+    # pip install -U selenium==${GEM_SELENIUM_VERSION}
 
     cp $GEM_GIT_PACKAGE/openquake/moon/test/config/moon_config.py.tmpl $GEM_GIT_PACKAGE/openquake/moon/test/config/moon_config.py
     export DISPLAY=:1

--- a/verifier.sh
+++ b/verifier.sh
@@ -31,7 +31,7 @@ if [ "$GEM_EPHEM_CMD" = "" ]; then
     GEM_EPHEM_CMD="lxc-copy"
 fi
 if [ "$GEM_EPHEM_NAME" = "" ]; then
-    GEM_EPHEM_NAME="ubuntu16-x11-lxc-eph"
+    GEM_EPHEM_NAME="debian13-x11-lxc-eph"
 fi
 
 LXC_VER=$(lxc-ls --version | cut -d '.' -f 1)


### PR DESCRIPTION
To be able to run on modern python versions we must abandon `nose` to `pytest`.
We turned of screenshots because not mandatory for the first iteration of the migration.
Tests are green here: https://jenkins.vpn.openquake.org/job/zdevel_oq-moon/36/